### PR TITLE
Implement raw client that allows low-level handling of acks

### DIFF
--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -26,38 +26,17 @@ use embedded_io::asynch::{Read, Write};
 use heapless::Vec;
 use rand_core::RngCore;
 
-use crate::client::client_config::{ClientConfig, MqttVersion};
-use crate::encoding::variable_byte_integer::{VariableByteInteger, VariableByteIntegerDecoder};
-use crate::network::NetworkConnection;
-use crate::packet::v5::connack_packet::ConnackPacket;
-use crate::packet::v5::connect_packet::ConnectPacket;
-use crate::packet::v5::disconnect_packet::DisconnectPacket;
-use crate::packet::v5::mqtt_packet::Packet;
-use crate::packet::v5::pingreq_packet::PingreqPacket;
-use crate::packet::v5::pingresp_packet::PingrespPacket;
-use crate::packet::v5::puback_packet::PubackPacket;
-use crate::packet::v5::publish_packet::QualityOfService::QoS1;
-use crate::packet::v5::publish_packet::{PublishPacket, QualityOfService};
+use crate::client::client_config::ClientConfig;
+use crate::packet::v5::publish_packet::QualityOfService::{self, QoS1};
 use crate::packet::v5::reason_codes::ReasonCode;
-use crate::packet::v5::reason_codes::ReasonCode::{BuffError, NetworkError};
-use crate::packet::v5::suback_packet::SubackPacket;
-use crate::packet::v5::subscription_packet::SubscriptionPacket;
-use crate::packet::v5::unsuback_packet::UnsubackPacket;
-use crate::packet::v5::unsubscription_packet::UnsubscriptionPacket;
-use crate::utils::buffer_reader::BuffReader;
-use crate::utils::buffer_writer::BuffWriter;
-use crate::utils::types::BufferError;
+
+use super::raw_client::{Event, RawMqttClient};
 
 pub struct MqttClient<'a, T, const MAX_PROPERTIES: usize, R: RngCore>
 where
     T: Read + Write,
 {
-    connection: Option<NetworkConnection<T>>,
-    buffer: &'a mut [u8],
-    buffer_len: usize,
-    recv_buffer: &'a mut [u8],
-    recv_buffer_len: usize,
-    config: ClientConfig<'a, MAX_PROPERTIES, R>,
+    raw: RawMqttClient<'a, T, MAX_PROPERTIES, R>,
 }
 
 impl<'a, T, const MAX_PROPERTIES: usize, R> MqttClient<'a, T, MAX_PROPERTIES, R>
@@ -74,80 +53,14 @@ where
         config: ClientConfig<'a, MAX_PROPERTIES, R>,
     ) -> Self {
         Self {
-            connection: Some(NetworkConnection::new(network_driver)),
-            buffer,
-            buffer_len,
-            recv_buffer,
-            recv_buffer_len,
-            config,
-        }
-    }
-
-    async fn connect_to_broker_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let len = {
-            let mut connect = ConnectPacket::<'b, MAX_PROPERTIES, 0>::new();
-            connect.keep_alive = self.config.keep_alive;
-            self.config.add_max_packet_size_as_prop();
-            connect.property_len = connect.add_properties(&self.config.properties);
-            if self.config.username_flag {
-                connect.add_username(&self.config.username);
-            }
-            if self.config.password_flag {
-                connect.add_password(&self.config.password)
-            }
-            if self.config.will_flag {
-                connect.add_will(
-                    &self.config.will_topic,
-                    &self.config.will_payload,
-                    self.config.will_retain,
-                )
-            }
-            connect.add_client_id(&self.config.client_id);
-            connect.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        trace!("Sending connect");
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        //connack
-        let reason: Result<u8, BufferError> = {
-            trace!("Waiting for connack");
-
-            let read =
-                { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
-
-            let mut packet = ConnackPacket::<'b, MAX_PROPERTIES>::new();
-            if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-                if err == BufferError::PacketTypeMismatch {
-                    let mut disc = DisconnectPacket::<'b, MAX_PROPERTIES>::new();
-                    if disc.decode(&mut BuffReader::new(self.buffer, read)).is_ok() {
-                        error!("Client was disconnected with reason: ");
-                        return Err(ReasonCode::from(disc.disconnect_reason));
-                    }
-                }
-                Err(err)
-            } else {
-                Ok(packet.connect_reason_code)
-            }
-        };
-
-        if let Err(err) = reason {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-        let res = reason.unwrap();
-        if res != 0x00 {
-            return Err(ReasonCode::from(res));
-        } else {
-            Ok(())
+            raw: RawMqttClient::new(
+                network_driver,
+                buffer,
+                buffer_len,
+                recv_buffer,
+                recv_buffer_len,
+                config,
+            ),
         }
     }
 
@@ -156,33 +69,14 @@ where
     /// If the connection to the broker fails, method returns Err variable that contains
     /// Reason codes returned from the broker.
     pub async fn connect_to_broker<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.connect_to_broker_v5().await,
-        }
-    }
+        self.raw.connect_to_broker().await?;
 
-    async fn disconnect_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
+        match self.raw.poll::<0>().await? {
+            Event::Connack => Ok(()),
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
-        let conn = self.connection.as_mut().unwrap();
-        trace!("Creating disconnect packet!");
-        let mut disconnect = DisconnectPacket::<'b, MAX_PROPERTIES>::new();
-        let len = disconnect.encode(self.buffer, self.buffer_len);
-        if let Err(err) = len {
-            warn!("[DECODE ERR]: {}", err);
-            let _ = self.connection.take();
-            return Err(ReasonCode::BuffError);
-        }
-
-        if let Err(_e) = conn.send(&self.buffer[0..len.unwrap()]).await {
-            warn!("Could not send DISCONNECT packet");
-        }
-
-        // Drop connection
-        let _ = self.connection.take();
-        Ok(())
     }
 
     /// Method allows client disconnect from the server. Client disconnects from the specified broker
@@ -190,73 +84,10 @@ where
     /// If the disconnect from the broker fails, method returns Err variable that contains
     /// Reason codes returned from the broker.
     pub async fn disconnect<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.disconnect_v5().await,
-        }
-    }
-
-    async fn send_message_v5<'b>(
-        &'b mut self,
-        topic_name: &'b str,
-        message: &'b [u8],
-        qos: QualityOfService,
-        retain: bool,
-    ) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        let identifier: u16 = self.config.rng.next_u32() as u16;
-        //self.rng.next_u32() as u16;
-        let len = {
-            let mut packet = PublishPacket::<'b, MAX_PROPERTIES>::new();
-            packet.add_topic_name(topic_name);
-            packet.add_qos(qos);
-            packet.add_identifier(identifier);
-            packet.add_message(message);
-            packet.add_retain(retain);
-            packet.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-        trace!("Sending message");
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        // QoS1
-        if qos == QoS1 {
-            let reason: Result<[u16; 2], BufferError> = {
-                trace!("Waiting for ack");
-                let read =
-                    receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await?;
-                trace!("[PUBACK] Received packet with len");
-                let mut packet = PubackPacket::<'b, MAX_PROPERTIES>::new();
-                if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-                    Err(err)
-                } else {
-                    Ok([packet.packet_identifier, packet.reason_code as u16])
-                }
-            };
-
-            if let Err(err) = reason {
-                error!("[DECODE ERR]: {}", err);
-                return Err(ReasonCode::BuffError);
-            }
-
-            let res = reason.unwrap();
-            if identifier != res[0] {
-                return Err(ReasonCode::PacketIdentifierNotFound);
-            }
-
-            if res[1] != 0 {
-                return Err(ReasonCode::from(res[1] as u8));
-            }
-        }
+        self.raw.disconnect().await?;
         Ok(())
     }
+
     /// Method allows sending message to broker specified from the ClientConfig. Client sends the
     /// message from the parameter `message` to the topic `topic_name` on the broker
     /// specified in the ClientConfig. If the send fails method returns Err with reason code
@@ -268,70 +99,28 @@ where
         qos: QualityOfService,
         retain: bool,
     ) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.send_message_v5(topic_name, message, qos, retain).await,
-        }
-    }
+        let identifier = self
+            .raw
+            .send_message(topic_name, message, qos, retain)
+            .await?;
 
-    async fn subscribe_to_topics_v5<'b, const TOPICS: usize>(
-        &'b mut self,
-        topic_names: &'b Vec<&'b str, TOPICS>,
-    ) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        let len = {
-            let mut subs = SubscriptionPacket::<'b, TOPICS, MAX_PROPERTIES>::new();
-            let mut i = 0;
-            loop {
-                if i == TOPICS {
-                    break;
+        // QoS1
+        if qos == QoS1 {
+            match self.raw.poll::<0>().await? {
+                Event::Puback(ack_identifier) => {
+                    if identifier == ack_identifier {
+                        Ok(())
+                    } else {
+                        Err(ReasonCode::PacketIdentifierNotFound)
+                    }
                 }
-                subs.add_new_filter(topic_names.get(i).unwrap(), self.config.max_subscribe_qos);
-                i = i + 1;
+                Event::Disconnect(reason) => Err(reason),
+                // If an application message comes at this moment, it is lost.
+                _ => Err(ReasonCode::ImplementationSpecificError),
             }
-            subs.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
+        } else {
+            Ok(())
         }
-
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        let reason: Result<Vec<u8, TOPICS>, BufferError> = {
-            let read =
-                { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
-
-            let mut packet = SubackPacket::<'b, TOPICS, MAX_PROPERTIES>::new();
-            if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-                Err(err)
-            } else {
-                Ok(packet.reason_codes)
-            }
-        };
-
-        if let Err(err) = reason {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-        let reasons = reason.unwrap();
-        let mut i = 0;
-        loop {
-            if i == TOPICS {
-                break;
-            }
-            if *reasons.get(i).unwrap()
-                != (<QualityOfService as Into<u8>>::into(self.config.max_subscribe_qos) >> 1)
-            {
-                return Err(ReasonCode::from(*reasons.get(i).unwrap()));
-            }
-            i = i + 1;
-        }
-        Ok(())
     }
 
     /// Method allows client subscribe to multiple topics specified in the parameter
@@ -342,9 +131,19 @@ where
         &'b mut self,
         topic_names: &'b Vec<&'b str, TOPICS>,
     ) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.subscribe_to_topics_v5(topic_names).await,
+        let identifier = self.raw.subscribe_to_topics(topic_names).await?;
+
+        match self.raw.poll::<TOPICS>().await? {
+            Event::Suback(ack_identifier) => {
+                if identifier == ack_identifier {
+                    Ok(())
+                } else {
+                    Err(ReasonCode::PacketIdentifierNotFound)
+                }
+            }
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
     }
 
@@ -355,97 +154,19 @@ where
         &'b mut self,
         topic_name: &'b str,
     ) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.unsubscribe_from_topic_v5(topic_name).await,
-        }
-    }
+        let identifier = self.raw.unsubscribe_from_topic(topic_name).await?;
 
-    async fn unsubscribe_from_topic_v5<'b>(
-        &'b mut self,
-        topic_name: &'b str,
-    ) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-
-        let len = {
-            let mut unsub = UnsubscriptionPacket::<'b, 1, MAX_PROPERTIES>::new();
-            unsub.packet_identifier = self.config.rng.next_u32() as u16;
-            unsub.add_new_filter(topic_name);
-            unsub.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        let reason: Result<u8, BufferError> = {
-            let read =
-                { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
-            let mut packet = UnsubackPacket::<'b, 1, MAX_PROPERTIES>::new();
-
-            if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-                Err(err)
-            } else {
-                Ok(*packet.reason_codes.get(0).unwrap())
+        match self.raw.poll::<0>().await? {
+            Event::Unsuback(ack_identifier) => {
+                if identifier == ack_identifier {
+                    Ok(())
+                } else {
+                    Err(ReasonCode::PacketIdentifierNotFound)
+                }
             }
-        };
-
-        if let Err(err) = reason {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-
-        Ok(())
-    }
-
-    async fn subscribe_to_topic_v5<'b>(
-        &'b mut self,
-        topic_name: &'b str,
-    ) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        let len = {
-            let mut subs = SubscriptionPacket::<'b, 1, MAX_PROPERTIES>::new();
-            subs.add_new_filter(topic_name, self.config.max_subscribe_qos);
-            subs.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        let reason: Result<u8, BufferError> = {
-            let read =
-                { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
-
-            let mut packet = SubackPacket::<'b, 1, MAX_PROPERTIES>::new();
-            if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-                Err(err)
-            } else {
-                Ok(*packet.reason_codes.get(0).unwrap())
-            }
-        };
-
-        if let Err(err) = reason {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-
-        let res = reason.unwrap();
-        if res != (<QualityOfService as Into<u8>>::into(self.config.max_subscribe_qos) >> 1) {
-            Err(ReasonCode::from(res))
-        } else {
-            Ok(())
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
     }
 
@@ -456,85 +177,34 @@ where
         &'b mut self,
         topic_name: &'b str,
     ) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.subscribe_to_topic_v5(topic_name).await,
-        }
-    }
+        let mut topic_names = Vec::<&'b str, 1>::new();
+        topic_names.push(topic_name).unwrap();
 
-    async fn receive_message_v5<'b>(&'b mut self) -> Result<(&'b str, &'b [u8]), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        let read = { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
+        let identifier = self.raw.subscribe_to_topics(&topic_names).await?;
 
-        let mut packet = PublishPacket::<'b, 5>::new();
-        if let Err(err) = { packet.decode(&mut BuffReader::new(self.buffer, read)) } {
-            if err == BufferError::PacketTypeMismatch {
-                let mut disc = DisconnectPacket::<'b, 5>::new();
-                if disc.decode(&mut BuffReader::new(self.buffer, read)).is_ok() {
-                    error!("Client was disconnected with reason: ");
-                    return Err(ReasonCode::from(disc.disconnect_reason));
+        match self.raw.poll::<1>().await? {
+            Event::Suback(ack_identifier) => {
+                if identifier == ack_identifier {
+                    Ok(())
+                } else {
+                    Err(ReasonCode::PacketIdentifierNotFound)
                 }
             }
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
-
-        if (packet.fixed_header & 0x06)
-            == <QualityOfService as Into<u8>>::into(QualityOfService::QoS1)
-        {
-            let mut puback = PubackPacket::<'b, MAX_PROPERTIES>::new();
-            puback.packet_identifier = packet.packet_identifier;
-            puback.reason_code = 0x00;
-            {
-                let len = { puback.encode(self.recv_buffer, self.recv_buffer_len) };
-                if let Err(err) = len {
-                    error!("[DECODE ERR]: {}", err);
-                    return Err(ReasonCode::BuffError);
-                }
-                conn.send(&self.recv_buffer[0..len.unwrap()]).await?;
-            }
-        }
-
-        return Ok((packet.topic_name.string, packet.message.unwrap()));
     }
 
     /// Method allows client receive a message. The work of this method strictly depends on the
     /// network implementation passed in the `ClientConfig`. It expects the PUBLISH packet
     /// from the broker.
     pub async fn receive_message<'b>(&'b mut self) -> Result<(&'b str, &'b [u8]), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.receive_message_v5().await,
-        }
-    }
-
-    async fn send_ping_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        if self.connection.is_none() {
-            return Err(ReasonCode::NetworkError);
-        }
-        let conn = self.connection.as_mut().unwrap();
-        let len = {
-            let mut packet = PingreqPacket::new();
-            packet.encode(self.buffer, self.buffer_len)
-        };
-
-        if let Err(err) = len {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        }
-
-        conn.send(&self.buffer[0..len.unwrap()]).await?;
-
-        let read = { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
-        let mut packet = PingrespPacket::new();
-        if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
-            error!("[DECODE ERR]: {}", err);
-            return Err(ReasonCode::BuffError);
-        } else {
-            Ok(())
+        match self.raw.poll::<0>().await? {
+            Event::Message(topic, payload) => Ok((topic, payload)),
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
     }
 
@@ -542,96 +212,13 @@ where
     /// If there is expectation for long running connection. Method should be executed
     /// regularly by the timer that counts down the session expiry interval.
     pub async fn send_ping<'b>(&'b mut self) -> Result<(), ReasonCode> {
-        match self.config.mqtt_version {
-            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
-            MqttVersion::MQTTv5 => self.send_ping_v5().await,
-        }
-    }
-}
+        self.raw.send_ping().await?;
 
-#[cfg(not(feature = "tls"))]
-async fn receive_packet<'c, T: Read + Write>(
-    buffer: &mut [u8],
-    buffer_len: usize,
-    recv_buffer: &mut [u8],
-    conn: &'c mut NetworkConnection<T>,
-) -> Result<usize, ReasonCode> {
-    let target_len: usize;
-    let mut rem_len: Result<VariableByteInteger, ()>;
-    let mut writer = BuffWriter::new(buffer, buffer_len);
-    let mut i = 0;
-
-    // Get len of packet
-    trace!("Reading lenght of packet");
-    loop {
-        trace!("    Reading in loop!");
-        let len: usize = conn
-            .receive(&mut recv_buffer[writer.position..(writer.position + 1)])
-            .await?;
-        trace!("    Received data!");
-        if len == 0 {
-            trace!("Zero byte len packet received, dropping connection.");
-            return Err(NetworkError);
-        }
-        i = i + len;
-        if let Err(_e) = writer.insert_ref(len, &recv_buffer[writer.position..i]) {
-            error!("Error occurred during write to buffer!");
-            return Err(ReasonCode::BuffError);
-        }
-        if i > 1 {
-            rem_len = writer.get_rem_len();
-            if rem_len.is_ok() {
-                break;
-            }
-            if i >= 5 {
-                error!("Could not read len of packet!");
-                return Err(NetworkError);
-            }
+        match self.raw.poll::<0>().await? {
+            Event::Pingresp => Ok(()),
+            Event::Disconnect(reason) => Err(reason),
+            // If an application message comes at this moment, it is lost.
+            _ => Err(ReasonCode::ImplementationSpecificError),
         }
     }
-    trace!("Lenght done!");
-    let rem_len_len = i;
-    i = 0;
-    if let Ok(l) = VariableByteIntegerDecoder::decode(rem_len.unwrap()) {
-        trace!("Reading packet with target len {}", l);
-        target_len = l as usize;
-    } else {
-        error!("Could not decode len of packet!");
-        return Err(BuffError);
-    }
-
-    loop {
-        if writer.position == target_len + rem_len_len {
-            trace!("Received packet with len: {}", (target_len + rem_len_len));
-            return Ok(target_len + rem_len_len);
-        }
-        let len: usize = conn
-            .receive(&mut recv_buffer[writer.position..writer.position + (target_len - i)])
-            .await?;
-        i = i + len;
-        if let Err(_e) =
-            writer.insert_ref(len, &recv_buffer[writer.position..(writer.position + i)])
-        {
-            error!("Error occurred during write to buffer!");
-            return Err(BuffError);
-        }
-    }
-}
-
-#[cfg(feature = "tls")]
-async fn receive_packet<'c, T: Read + Write>(
-    buffer: &mut [u8],
-    buffer_len: usize,
-    recv_buffer: &mut [u8],
-    conn: &'c mut NetworkConnection<T>,
-) -> Result<usize, ReasonCode> {
-    trace!("Reading packet");
-    let mut writer = BuffWriter::new(buffer, buffer_len);
-    let len = conn.receive(recv_buffer).await?;
-    if let Err(_e) = writer.insert_ref(len, &recv_buffer[writer.position..(writer.position + len)])
-    {
-        error!("Error occurred during write to buffer!");
-        return Err(BuffError);
-    }
-    Ok(len)
 }

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -25,3 +25,4 @@
 pub mod client;
 #[allow(unused_must_use)]
 pub mod client_config;
+pub mod raw_client;

--- a/src/client/raw_client.rs
+++ b/src/client/raw_client.rs
@@ -1,0 +1,577 @@
+use embedded_io::asynch::{Read, Write};
+use heapless::Vec;
+use rand_core::RngCore;
+
+use crate::{
+    encoding::variable_byte_integer::{VariableByteInteger, VariableByteIntegerDecoder},
+    network::NetworkConnection,
+    packet::v5::{
+        connack_packet::ConnackPacket,
+        connect_packet::ConnectPacket,
+        disconnect_packet::DisconnectPacket,
+        mqtt_packet::Packet,
+        packet_type::PacketType,
+        pingreq_packet::PingreqPacket,
+        pingresp_packet::PingrespPacket,
+        puback_packet::PubackPacket,
+        publish_packet::{PublishPacket, QualityOfService},
+        reason_codes::ReasonCode,
+        suback_packet::SubackPacket,
+        subscription_packet::SubscriptionPacket,
+        unsuback_packet::UnsubackPacket,
+        unsubscription_packet::UnsubscriptionPacket,
+    },
+    utils::{buffer_reader::BuffReader, buffer_writer::BuffWriter, types::BufferError},
+};
+
+use super::client_config::{ClientConfig, MqttVersion};
+
+pub enum Event<'a> {
+    Connack,
+    Puback(u16),
+    Suback(u16),
+    Unsuback(u16),
+    Pingresp,
+    Message(&'a str, &'a [u8]),
+    Disconnect(ReasonCode),
+}
+
+pub struct RawMqttClient<'a, T, const MAX_PROPERTIES: usize, R: RngCore>
+where
+    T: Read + Write,
+{
+    connection: Option<NetworkConnection<T>>,
+    buffer: &'a mut [u8],
+    buffer_len: usize,
+    recv_buffer: &'a mut [u8],
+    recv_buffer_len: usize,
+    config: ClientConfig<'a, MAX_PROPERTIES, R>,
+}
+
+impl<'a, T, const MAX_PROPERTIES: usize, R> RawMqttClient<'a, T, MAX_PROPERTIES, R>
+where
+    T: Read + Write,
+    R: RngCore,
+{
+    pub fn new(
+        network_driver: T,
+        buffer: &'a mut [u8],
+        buffer_len: usize,
+        recv_buffer: &'a mut [u8],
+        recv_buffer_len: usize,
+        config: ClientConfig<'a, MAX_PROPERTIES, R>,
+    ) -> Self {
+        Self {
+            connection: Some(NetworkConnection::new(network_driver)),
+            buffer,
+            buffer_len,
+            recv_buffer,
+            recv_buffer_len,
+            config,
+        }
+    }
+
+    async fn connect_to_broker_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let len = {
+            let mut connect = ConnectPacket::<'b, MAX_PROPERTIES, 0>::new();
+            connect.keep_alive = self.config.keep_alive;
+            self.config.add_max_packet_size_as_prop();
+            connect.property_len = connect.add_properties(&self.config.properties);
+            if self.config.username_flag {
+                connect.add_username(&self.config.username);
+            }
+            if self.config.password_flag {
+                connect.add_password(&self.config.password)
+            }
+            if self.config.will_flag {
+                connect.add_will(
+                    &self.config.will_topic,
+                    &self.config.will_payload,
+                    self.config.will_retain,
+                )
+            }
+            connect.add_client_id(&self.config.client_id);
+            connect.encode(self.buffer, self.buffer_len)
+        };
+
+        if let Err(err) = len {
+            error!("[DECODE ERR]: {}", err);
+            return Err(ReasonCode::BuffError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        trace!("Sending connect");
+        conn.send(&self.buffer[0..len.unwrap()]).await?;
+
+        Ok(())
+    }
+
+    /// Method allows client connect to server. Client is connecting to the specified broker
+    /// in the `ClientConfig`. Method selects proper implementation of the MQTT version based on the config.
+    /// If the connection to the broker fails, method returns Err variable that contains
+    /// Reason codes returned from the broker.
+    pub async fn connect_to_broker<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.connect_to_broker_v5().await,
+        }
+    }
+
+    async fn disconnect_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        trace!("Creating disconnect packet!");
+        let mut disconnect = DisconnectPacket::<'b, MAX_PROPERTIES>::new();
+        let len = disconnect.encode(self.buffer, self.buffer_len);
+        if let Err(err) = len {
+            warn!("[DECODE ERR]: {}", err);
+            let _ = self.connection.take();
+            return Err(ReasonCode::BuffError);
+        }
+
+        if let Err(_e) = conn.send(&self.buffer[0..len.unwrap()]).await {
+            warn!("Could not send DISCONNECT packet");
+        }
+
+        // Drop connection
+        let _ = self.connection.take();
+        Ok(())
+    }
+
+    /// Method allows client disconnect from the server. Client disconnects from the specified broker
+    /// in the `ClientConfig`. Method selects proper implementation of the MQTT version based on the config.
+    /// If the disconnect from the broker fails, method returns Err variable that contains
+    /// Reason codes returned from the broker.
+    pub async fn disconnect<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.disconnect_v5().await,
+        }
+    }
+
+    async fn send_message_v5<'b>(
+        &'b mut self,
+        topic_name: &'b str,
+        message: &'b [u8],
+        qos: QualityOfService,
+        retain: bool,
+    ) -> Result<u16, ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        let identifier: u16 = self.config.rng.next_u32() as u16;
+        //self.rng.next_u32() as u16;
+        let len = {
+            let mut packet = PublishPacket::<'b, MAX_PROPERTIES>::new();
+            packet.add_topic_name(topic_name);
+            packet.add_qos(qos);
+            packet.add_identifier(identifier);
+            packet.add_message(message);
+            packet.add_retain(retain);
+            packet.encode(self.buffer, self.buffer_len)
+        };
+
+        if let Err(err) = len {
+            error!("[DECODE ERR]: {}", err);
+            return Err(ReasonCode::BuffError);
+        }
+        trace!("Sending message");
+        conn.send(&self.buffer[0..len.unwrap()]).await?;
+
+        Ok(identifier)
+    }
+    /// Method allows sending message to broker specified from the ClientConfig. Client sends the
+    /// message from the parameter `message` to the topic `topic_name` on the broker
+    /// specified in the ClientConfig. If the send fails method returns Err with reason code
+    /// received by broker.
+    pub async fn send_message<'b>(
+        &'b mut self,
+        topic_name: &'b str,
+        message: &'b [u8],
+        qos: QualityOfService,
+        retain: bool,
+    ) -> Result<u16, ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.send_message_v5(topic_name, message, qos, retain).await,
+        }
+    }
+
+    async fn subscribe_to_topics_v5<'b, const TOPICS: usize>(
+        &'b mut self,
+        topic_names: &'b Vec<&'b str, TOPICS>,
+    ) -> Result<u16, ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        let identifier: u16 = self.config.rng.next_u32() as u16;
+        let len = {
+            let mut subs = SubscriptionPacket::<'b, TOPICS, MAX_PROPERTIES>::new();
+            subs.packet_identifier = identifier;
+            let mut i = 0;
+            loop {
+                if i == TOPICS {
+                    break;
+                }
+                subs.add_new_filter(topic_names.get(i).unwrap(), self.config.max_subscribe_qos);
+                i = i + 1;
+            }
+            subs.encode(self.buffer, self.buffer_len)
+        };
+
+        if let Err(err) = len {
+            error!("[DECODE ERR]: {}", err);
+            return Err(ReasonCode::BuffError);
+        }
+
+        conn.send(&self.buffer[0..len.unwrap()]).await?;
+
+        Ok(identifier)
+    }
+
+    /// Method allows client subscribe to multiple topics specified in the parameter
+    /// `topic_names` on the broker specified in the `ClientConfig`. Generics `TOPICS`
+    /// sets the value of the `topics_names` vector. MQTT protocol implementation
+    /// is selected automatically.
+    pub async fn subscribe_to_topics<'b, const TOPICS: usize>(
+        &'b mut self,
+        topic_names: &'b Vec<&'b str, TOPICS>,
+    ) -> Result<u16, ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.subscribe_to_topics_v5(topic_names).await,
+        }
+    }
+
+    /// Method allows client unsubscribe from the topic specified in the parameter
+    /// `topic_name` on the broker from the `ClientConfig`. MQTT protocol implementation
+    /// is selected automatically.
+    pub async fn unsubscribe_from_topic<'b>(
+        &'b mut self,
+        topic_name: &'b str,
+    ) -> Result<u16, ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.unsubscribe_from_topic_v5(topic_name).await,
+        }
+    }
+
+    async fn unsubscribe_from_topic_v5<'b>(
+        &'b mut self,
+        topic_name: &'b str,
+    ) -> Result<u16, ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        let identifier = self.config.rng.next_u32() as u16;
+
+        let len = {
+            let mut unsub = UnsubscriptionPacket::<'b, 1, MAX_PROPERTIES>::new();
+            unsub.packet_identifier = identifier;
+            unsub.add_new_filter(topic_name);
+            unsub.encode(self.buffer, self.buffer_len)
+        };
+
+        if let Err(err) = len {
+            error!("[DECODE ERR]: {}", err);
+            return Err(ReasonCode::BuffError);
+        }
+        conn.send(&self.buffer[0..len.unwrap()]).await?;
+
+        Ok(identifier)
+    }
+
+    async fn send_ping_v5<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+        let conn = self.connection.as_mut().unwrap();
+        let len = {
+            let mut packet = PingreqPacket::new();
+            packet.encode(self.buffer, self.buffer_len)
+        };
+
+        if let Err(err) = len {
+            error!("[DECODE ERR]: {}", err);
+            return Err(ReasonCode::BuffError);
+        }
+
+        conn.send(&self.buffer[0..len.unwrap()]).await?;
+
+        Ok(())
+    }
+
+    /// Method allows client send PING message to the broker specified in the `ClientConfig`.
+    /// If there is expectation for long running connection. Method should be executed
+    /// regularly by the timer that counts down the session expiry interval.
+    pub async fn send_ping<'b>(&'b mut self) -> Result<(), ReasonCode> {
+        match self.config.mqtt_version {
+            MqttVersion::MQTTv3 => Err(ReasonCode::UnsupportedProtocolVersion),
+            MqttVersion::MQTTv5 => self.send_ping_v5().await,
+        }
+    }
+
+    pub async fn poll<'b, const MAX_TOPICS: usize>(&'b mut self) -> Result<Event<'b>, ReasonCode> {
+        if self.connection.is_none() {
+            return Err(ReasonCode::NetworkError);
+        }
+
+        let conn = self.connection.as_mut().unwrap();
+
+        trace!("Waiting for a packet");
+
+        let read = { receive_packet(self.buffer, self.buffer_len, self.recv_buffer, conn).await? };
+
+        let buf_reader = BuffReader::new(self.buffer, read);
+
+        match PacketType::from(buf_reader.peek_u8().map_err(|_| ReasonCode::BuffError)?) {
+            PacketType::Reserved
+            | PacketType::Connect
+            | PacketType::Subscribe
+            | PacketType::Unsubscribe
+            | PacketType::Pingreq => Err(ReasonCode::ProtocolError),
+            PacketType::Pubrec | PacketType::Pubrel | PacketType::Pubcomp | PacketType::Auth => {
+                Err(ReasonCode::ImplementationSpecificError)
+            }
+            PacketType::Connack => {
+                let mut packet = ConnackPacket::<'b, MAX_PROPERTIES>::new();
+                if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
+                    // if err == BufferError::PacketTypeMismatch {
+                    //     let mut disc = DisconnectPacket::<'b, MAX_PROPERTIES>::new();
+                    //     if disc.decode(&mut BuffReader::new(self.buffer, read)).is_ok() {
+                    //         error!("Client was disconnected with reason: ");
+                    //         return Err(ReasonCode::from(disc.disconnect_reason));
+                    //     }
+                    // }
+                    error!("[DECODE ERR]: {}", err);
+                    Err(ReasonCode::BuffError)
+                } else if packet.connect_reason_code != 0x00 {
+                    Err(ReasonCode::from(packet.connect_reason_code))
+                } else {
+                    Ok(Event::Connack)
+                }
+            }
+            PacketType::Puback => {
+                let reason: Result<[u16; 2], BufferError> = {
+                    let mut packet = PubackPacket::<'b, MAX_PROPERTIES>::new();
+                    if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
+                        Err(err)
+                    } else {
+                        Ok([packet.packet_identifier, packet.reason_code as u16])
+                    }
+                };
+
+                if let Err(err) = reason {
+                    error!("[DECODE ERR]: {}", err);
+                    return Err(ReasonCode::BuffError);
+                }
+
+                let res = reason.unwrap();
+
+                if res[1] != 0 {
+                    return Err(ReasonCode::from(res[1] as u8));
+                }
+
+                Ok(Event::Puback(res[0]))
+            }
+            PacketType::Suback => {
+                let reason: Result<(u16, Vec<u8, MAX_TOPICS>), BufferError> = {
+                    let mut packet = SubackPacket::<'b, MAX_TOPICS, MAX_PROPERTIES>::new();
+                    if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
+                        Err(err)
+                    } else {
+                        Ok((packet.packet_identifier, packet.reason_codes))
+                    }
+                };
+
+                if let Err(err) = reason {
+                    error!("[DECODE ERR]: {}", err);
+                    return Err(ReasonCode::BuffError);
+                }
+                let (packet_identifier, reasons) = reason.unwrap();
+                let mut i = 0;
+                loop {
+                    if i == reasons.len() {
+                        break;
+                    }
+                    if *reasons.get(i).unwrap()
+                        != (<QualityOfService as Into<u8>>::into(self.config.max_subscribe_qos)
+                            >> 1)
+                    {
+                        return Err(ReasonCode::from(*reasons.get(i).unwrap()));
+                    }
+                    i = i + 1;
+                }
+                Ok(Event::Suback(packet_identifier))
+            }
+            PacketType::Unsuback => {
+                let res: Result<u16, BufferError> = {
+                    let mut packet = UnsubackPacket::<'b, 1, MAX_PROPERTIES>::new();
+
+                    if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
+                        Err(err)
+                    } else {
+                        Ok(packet.packet_identifier)
+                    }
+                };
+
+                if let Err(err) = res {
+                    error!("[DECODE ERR]: {}", err);
+                    Err(ReasonCode::BuffError)
+                } else {
+                    Ok(Event::Unsuback(res.unwrap()))
+                }
+            }
+            PacketType::Pingresp => {
+                let mut packet = PingrespPacket::new();
+                if let Err(err) = packet.decode(&mut BuffReader::new(self.buffer, read)) {
+                    error!("[DECODE ERR]: {}", err);
+                    return Err(ReasonCode::BuffError);
+                } else {
+                    Ok(Event::Pingresp)
+                }
+            }
+            PacketType::Publish => {
+                let mut packet = PublishPacket::<'b, 5>::new();
+                if let Err(err) = { packet.decode(&mut BuffReader::new(self.buffer, read)) } {
+                    // if err == BufferError::PacketTypeMismatch {
+                    //     let mut disc = DisconnectPacket::<'b, 5>::new();
+                    //     if disc.decode(&mut BuffReader::new(self.buffer, read)).is_ok() {
+                    //         error!("Client was disconnected with reason: ");
+                    //         return Err(ReasonCode::from(disc.disconnect_reason));
+                    //     }
+                    // }
+                    error!("[DECODE ERR]: {}", err);
+                    return Err(ReasonCode::BuffError);
+                }
+
+                if (packet.fixed_header & 0x06)
+                    == <QualityOfService as Into<u8>>::into(QualityOfService::QoS1)
+                {
+                    let mut puback = PubackPacket::<'b, MAX_PROPERTIES>::new();
+                    puback.packet_identifier = packet.packet_identifier;
+                    puback.reason_code = 0x00;
+                    {
+                        let len = { puback.encode(self.recv_buffer, self.recv_buffer_len) };
+                        if let Err(err) = len {
+                            error!("[DECODE ERR]: {}", err);
+                            return Err(ReasonCode::BuffError);
+                        }
+                        conn.send(&self.recv_buffer[0..len.unwrap()]).await?;
+                    }
+                }
+
+                Ok(Event::Message(
+                    packet.topic_name.string,
+                    packet.message.unwrap(),
+                ))
+            }
+            PacketType::Disconnect => {
+                let mut disc = DisconnectPacket::<'b, 5>::new();
+                let res = disc.decode(&mut BuffReader::new(self.buffer, read));
+
+                match res {
+                    Ok(_) => Ok(Event::Disconnect(ReasonCode::from(disc.disconnect_reason))),
+                    Err(err) => {
+                        error!("[DECODE ERR]: {}", err);
+                        Err(ReasonCode::BuffError)
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "tls"))]
+async fn receive_packet<'c, T: Read + Write>(
+    buffer: &mut [u8],
+    buffer_len: usize,
+    recv_buffer: &mut [u8],
+    conn: &'c mut NetworkConnection<T>,
+) -> Result<usize, ReasonCode> {
+    let target_len: usize;
+    let mut rem_len: Result<VariableByteInteger, ()>;
+    let mut writer = BuffWriter::new(buffer, buffer_len);
+    let mut i = 0;
+
+    // Get len of packet
+    trace!("Reading lenght of packet");
+    loop {
+        trace!("    Reading in loop!");
+        let len: usize = conn
+            .receive(&mut recv_buffer[writer.position..(writer.position + 1)])
+            .await?;
+        trace!("    Received data!");
+        if len == 0 {
+            trace!("Zero byte len packet received, dropping connection.");
+            return Err(ReasonCode::NetworkError);
+        }
+        i = i + len;
+        if let Err(_e) = writer.insert_ref(len, &recv_buffer[writer.position..i]) {
+            error!("Error occurred during write to buffer!");
+            return Err(ReasonCode::BuffError);
+        }
+        if i > 1 {
+            rem_len = writer.get_rem_len();
+            if rem_len.is_ok() {
+                break;
+            }
+            if i >= 5 {
+                error!("Could not read len of packet!");
+                return Err(ReasonCode::NetworkError);
+            }
+        }
+    }
+    trace!("Lenght done!");
+    let rem_len_len = i;
+    i = 0;
+    if let Ok(l) = VariableByteIntegerDecoder::decode(rem_len.unwrap()) {
+        trace!("Reading packet with target len {}", l);
+        target_len = l as usize;
+    } else {
+        error!("Could not decode len of packet!");
+        return Err(ReasonCode::BuffError);
+    }
+
+    loop {
+        if writer.position == target_len + rem_len_len {
+            trace!("Received packet with len: {}", (target_len + rem_len_len));
+            return Ok(target_len + rem_len_len);
+        }
+        let len: usize = conn
+            .receive(&mut recv_buffer[writer.position..writer.position + (target_len - i)])
+            .await?;
+        i = i + len;
+        if let Err(_e) =
+            writer.insert_ref(len, &recv_buffer[writer.position..(writer.position + i)])
+        {
+            error!("Error occurred during write to buffer!");
+            return Err(ReasonCode::BuffError);
+        }
+    }
+}
+
+#[cfg(feature = "tls")]
+async fn receive_packet<'c, T: Read + Write>(
+    buffer: &mut [u8],
+    buffer_len: usize,
+    recv_buffer: &mut [u8],
+    conn: &'c mut NetworkConnection<T>,
+) -> Result<usize, ReasonCode> {
+    trace!("Reading packet");
+    let mut writer = BuffWriter::new(buffer, buffer_len);
+    let len = conn.receive(recv_buffer).await?;
+    if let Err(_e) = writer.insert_ref(len, &recv_buffer[writer.position..(writer.position + len)])
+    {
+        error!("Error occurred during write to buffer!");
+        return Err(ReasonCode::BuffError);
+    }
+    Ok(len)
+}

--- a/src/utils/buffer_reader.rs
+++ b/src/utils/buffer_reader.rs
@@ -165,4 +165,13 @@ impl<'a> BuffReader<'a> {
         }
         return &self.buffer[self.position..total_len];
     }
+
+    /// Peeking (without incremental internal pointer) one byte from buffer as `Big endian`
+    pub fn peek_u8(&self) -> Result<u8, BufferError> {
+        if self.position >= self.len {
+            return Err(BufferError::InsufficientBufferSize);
+        }
+        let ret: u8 = self.buffer[self.position];
+        return Ok(ret);
+    }
 }


### PR DESCRIPTION
It's not really an event loop, but in the "raw" client I separated sending a packet from receiving a packet, so that users can opt in to low-level control if they need to (e.g., to handle packets that come *before* ack packets). Then I used this raw client inside the current client and tried to mimic the original behavior as well as I could.

I mostly copied parts of the code from the original client, there are not many real changes.